### PR TITLE
fix: polish food cards and home carousel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import Profile from "./client/pages/Profile";
 import Wishlist from "./client/pages/Wishlist";
 import React from "react";
 const Recipe = lazy(() => import("./client/pages/Recipe"));
+const isLocalHealthEnabled = import.meta.env.DEV;
 
 function App() {
 	return (
@@ -28,7 +29,9 @@ function App() {
 							<Route path="/food" element={<Food />} />
 							<Route path="/news" element={<News />} />
 							<Route path="/about" element={<About />} />
-							<Route path="/health" element={<Health />} />
+							{isLocalHealthEnabled && (
+								<Route path="/health" element={<Health />} />
+							)}
 							<Route path="/account" element={<Account />} />
 							<Route
 								path="/profile"

--- a/src/client/components/home/Carousel.jsx
+++ b/src/client/components/home/Carousel.jsx
@@ -14,6 +14,7 @@ const fallbackItems = [
 
 const Carousel = ({ items }) => {
 	const [currIndex, setCurrIndex] = useState(0);
+	const [isPaused, setIsPaused] = useState(false);
 	const displayItems = items.length ? items : fallbackItems;
 
 	const handleSpecSlide = (index) => {
@@ -38,7 +39,7 @@ const Carousel = ({ items }) => {
 	}, [currIndex, displayItems.length]);
 
 	useEffect(() => {
-		if (!displayItems.length) return undefined;
+		if (!displayItems.length || isPaused) return undefined;
 
 		const intervalId = setInterval(() => {
 			setCurrIndex((prevIndex) => (prevIndex + 1) % displayItems.length);
@@ -46,9 +47,13 @@ const Carousel = ({ items }) => {
 		return () => {
 			clearInterval(intervalId);
 		};
-	}, [displayItems.length]);
+	}, [displayItems.length, isPaused]);
 	return (
-		<div className="home__carousel">
+		<div
+			className="home__carousel"
+			onMouseEnter={() => setIsPaused(true)}
+			onMouseLeave={() => setIsPaused(false)}
+		>
 			<div
 				className="home__carousel__container"
 				style={{
@@ -63,6 +68,8 @@ const Carousel = ({ items }) => {
 							title={name}
 							desc={description}
 							imgSrc={imageName || name}
+							index={index}
+							total={displayItems.length}
 						/>
 					))}
 			</div>
@@ -74,6 +81,8 @@ const Carousel = ({ items }) => {
 					onSpecSlide={handleSpecSlide}
 					onPrevSlide={handlePrevSlide}
 					onNextSlide={handleNextSlide}
+					isPaused={isPaused}
+					onTogglePause={() => setIsPaused((value) => !value)}
 				/>
 			)}
 		</div>

--- a/src/client/components/home/carousel/CarouselItem.jsx
+++ b/src/client/components/home/carousel/CarouselItem.jsx
@@ -1,28 +1,41 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import convertImage from "../../../utils/convertImage";
-const CarouselItem = ({ id, title, desc, imgSrc }) => {
+const CarouselItem = ({ id, title, desc, imgSrc, index, total }) => {
 	const navigate = useNavigate();
 	const handleClick = () => {
 		navigate(id ? `/food?meals=${id}` : "/food");
 	};
+	const handleBrowseAll = () => {
+		navigate("/food");
+	};
 	return (
 		<div className="home__carousel__item">
 			<div className="home__carousel__item__content">
-				<span className="home__carousel__item__content__eyebrow">
-					Fresh inspiration
+				<span className="home__carousel__item__content__count">
+					{String(index + 1).padStart(2, "0")} /{" "}
+					{String(total).padStart(2, "0")}
 				</span>
 				<h1 className="home__carousel__item__content__title">
 					{title}
 				</h1>
 				<p className="home__carousel__item__content__desc">{desc}</p>
-				<button
-					type="button"
-					className="home__carousel__item__content__button btn btn-dark"
-					onClick={handleClick}
-				>
-					Explore recipes
-				</button>
+				<div className="home__carousel__item__content__actions">
+					<button
+						type="button"
+						className="home__carousel__item__content__button btn btn-dark"
+						onClick={handleClick}
+					>
+						Explore this meal
+					</button>
+					<button
+						type="button"
+						className="home__carousel__item__content__button home__carousel__item__content__button--ghost"
+						onClick={handleBrowseAll}
+					>
+						Browse all
+					</button>
+				</div>
 			</div>
 			<div className="home__carousel__item__media">
 				{convertImage(imgSrc, "home__carousel__item__img")}

--- a/src/client/components/home/carousel/CarouselNavBar.jsx
+++ b/src/client/components/home/carousel/CarouselNavBar.jsx
@@ -1,5 +1,10 @@
 import React from "react";
-import { BsChevronLeft, BsChevronRight } from "react-icons/bs";
+import {
+	BsChevronLeft,
+	BsChevronRight,
+	BsPauseFill,
+	BsPlayFill,
+} from "react-icons/bs";
 
 const CarouselNavBar = ({
 	currIndex,
@@ -7,6 +12,8 @@ const CarouselNavBar = ({
 	onSpecSlide,
 	onPrevSlide,
 	onNextSlide,
+	isPaused,
+	onTogglePause,
 }) => {
 	return (
 		<div className="home__carousel__nav">
@@ -45,6 +52,14 @@ const CarouselNavBar = ({
 				aria-label="Next featured slide"
 			>
 				<BsChevronRight size={16} />
+			</button>
+			<button
+				type="button"
+				className="home__carousel__nav__pause"
+				onClick={onTogglePause}
+				aria-label={isPaused ? "Resume featured carousel" : "Pause featured carousel"}
+			>
+				{isPaused ? <BsPlayFill size={15} /> : <BsPauseFill size={15} />}
 			</button>
 		</div>
 	);

--- a/src/client/components/layout/Header.jsx
+++ b/src/client/components/layout/Header.jsx
@@ -22,10 +22,14 @@ const items = [
 		title: "About",
 		href: "/about",
 	},
-	{
-		title: "Health",
-		href: "/health",
-	},
+	...(import.meta.env.DEV
+		? [
+				{
+					title: "Health",
+					href: "/health",
+				},
+		  ]
+		: []),
 	{
 		title: "Wishlist",
 		href: "/wishlist",

--- a/src/client/styles/Food.scss
+++ b/src/client/styles/Food.scss
@@ -391,7 +391,7 @@
 				&__item {
 					position: relative;
 					overflow: hidden;
-					min-height: 420px;
+					height: 392px;
 					border: 1px solid rgba(98, 58, 18, 0.1);
 					border-radius: 8px;
 					background: #ffffff;
@@ -410,14 +410,17 @@
 
 					&__img {
 						width: 100%;
-						height: 220px;
+						height: 208px;
+						flex: 0 0 208px;
 						object-fit: cover;
+						object-position: center;
 					}
 
 					&__context {
 						display: flex;
 						flex: 1;
 						flex-direction: column;
+						min-height: 0;
 						padding: 1rem;
 
 						strong {
@@ -437,14 +440,20 @@
 						display: flex;
 						flex-wrap: wrap;
 						gap: 0.45rem;
+						min-height: 1.65rem;
+						overflow: hidden;
 
 						span {
+							max-width: 100%;
+							overflow: hidden;
 							padding: 0.25rem 0.55rem;
 							border-radius: 999px;
 							background: rgba(255, 159, 28, 0.15);
 							color: #a84f00;
 							font-size: 0.76rem;
 							font-weight: 900;
+							text-overflow: ellipsis;
+							white-space: nowrap;
 						}
 					}
 
@@ -473,6 +482,7 @@
 
 				&--list &__item {
 					min-height: 190px;
+					height: 190px;
 					display: grid;
 					grid-template-columns: minmax(180px, 240px) minmax(0, 1fr);
 
@@ -558,9 +568,11 @@
 
 					&--list &__item {
 						grid-template-columns: 1fr;
+						height: auto;
+						min-height: 0;
 
 						&__img {
-							height: 220px;
+							height: 208px;
 						}
 					}
 				}

--- a/src/client/styles/Home.scss
+++ b/src/client/styles/Home.scss
@@ -16,52 +16,59 @@
 		&__item {
 			width: 100vw;
 			flex: 0 0 100vw;
-			min-height: 560px;
+			min-height: 390px;
 			display: grid;
-			grid-template-columns: minmax(320px, 0.92fr) minmax(0, 1.08fr);
+			grid-template-columns: minmax(320px, 0.9fr) minmax(0, 1.1fr);
 			align-items: stretch;
 			background:
 				linear-gradient(135deg, rgba(24, 17, 12, 0.96), rgba(67, 35, 20, 0.92)),
 				#211813;
 
 			&__content {
-				padding: clamp(4rem, 8vw, 7rem) clamp(1.5rem, 5vw, 5rem);
+				padding: clamp(3rem, 6vw, 4.8rem) clamp(1.5rem, 5vw, 5rem);
 				display: flex;
 				justify-content: center;
 				flex-direction: column;
 				color: #fff8ef;
 
-				&__eyebrow {
+				&__count {
 					width: fit-content;
-					margin-bottom: 1rem;
-					padding: 0.35rem 0.75rem;
+					margin-bottom: 0.8rem;
+					padding: 0.32rem 0.7rem;
 					border: 1px solid rgba(255, 255, 255, 0.28);
 					border-radius: 999px;
 					color: #ffd18b;
 					font-size: 0.78rem;
 					font-weight: 800;
-					text-transform: uppercase;
 				}
 
 				&__title {
-					max-width: 11ch;
-					margin-bottom: 1rem;
-					font-size: clamp(2.6rem, 6vw, 5.8rem);
+					max-width: 12ch;
+					margin-bottom: 0.75rem;
+					font-size: clamp(2.25rem, 5vw, 4.4rem);
 					font-weight: 900;
-					line-height: 0.95;
+					line-height: 0.98;
 				}
 
 				&__desc {
 					max-width: 58ch;
-					margin: 0 0 1.75rem 0;
+					margin: 0 0 1.2rem 0;
 					color: rgba(255, 248, 239, 0.82);
-					font-size: 1.05rem;
-					line-height: 1.75;
+					font-size: 0.98rem;
+					line-height: 1.65;
+				}
+
+				&__actions {
+					display: flex;
+					align-items: center;
+					flex-wrap: wrap;
+					gap: 0.7rem;
 				}
 
 				&__button {
 					width: fit-content;
-					padding: 0.85rem 1.3rem;
+					min-height: 2.75rem;
+					padding: 0 1.1rem;
 					border: none;
 					border-radius: 999px;
 					background-color: #ff9f1c;
@@ -78,12 +85,23 @@
 						transform: translateY(-2px);
 						box-shadow: 0 16px 36px rgba(255, 159, 28, 0.24);
 					}
+
+					&--ghost {
+						border: 1px solid rgba(255, 248, 239, 0.34);
+						background: rgba(255, 255, 255, 0.08);
+						color: #fff8ef;
+
+						&:hover {
+							background: rgba(255, 255, 255, 0.18);
+							color: #fff8ef;
+						}
+					}
 				}
 			}
 
 			&__media {
 				position: relative;
-				min-height: 560px;
+				min-height: 390px;
 				overflow: hidden;
 
 				&::after {
@@ -122,6 +140,24 @@
 			}
 
 			&__arrow {
+				width: 2.25rem;
+				height: 2.25rem;
+				border-radius: 50%;
+				background: rgba(255, 255, 255, 0.14);
+				color: #fff8ef;
+				transition:
+					background-color 0.2s ease,
+					color 0.2s ease,
+					transform 0.2s ease;
+
+				&:hover {
+					background: #ff9f1c;
+					color: #17110c;
+					transform: translateY(-1px);
+				}
+			}
+
+			&__pause {
 				width: 2.25rem;
 				height: 2.25rem;
 				border-radius: 50%;
@@ -514,7 +550,7 @@
 				grid-template-columns: 1fr;
 
 				&__content {
-					min-height: 500px;
+					min-height: 380px;
 					padding-bottom: 6rem;
 				}
 

--- a/src/client/utils/convertImage.jsx
+++ b/src/client/utils/convertImage.jsx
@@ -9,12 +9,25 @@ const images = import.meta.glob("../assets/images/*.{png,jpg,jpeg,webp,svg}", {
 	import: "default",
 });
 
+const imageAliases = {
+	cajun_seafood_pasta: "quick_shrimp_scampi",
+	molten_chocolate_mug_cake: "desserts",
+	vanilla_no_bake_cheesecake: "desserts",
+};
+
 const isRemoteImage = (src) =>
 	typeof src === "string" &&
 	(src.startsWith("http://") ||
 		src.startsWith("https://") ||
 		src.startsWith("data:") ||
 		src.startsWith("blob:"));
+
+const normalizeImageName = (value = "") =>
+	value
+		.toLowerCase()
+		.trim()
+		.replace(/[^a-z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "");
 
 const convertImage = (name = "Recipe image", className = "", imageUrl = "") => {
 	if (isRemoteImage(imageUrl)) {
@@ -29,10 +42,13 @@ const convertImage = (name = "Recipe image", className = "", imageUrl = "") => {
 		);
 	}
 
-	const normalizedName = name.toLowerCase().replaceAll(" ", "_");
+	const normalizedName = normalizeImageName(name);
+	const imageName = imageAliases[normalizedName] || normalizedName;
 
 	const imageEntry = Object.entries(images).find(([path]) =>
-		path.includes(`/assets/images/${normalizedName}.`)
+		normalizeImageName(path.split("/").pop()?.split(".")[0]).includes(
+			imageName
+		)
 	);
 
 	const imageSrc = imageEntry ? imageEntry[1] : default_image;


### PR DESCRIPTION
## Summary
- Fix Food page recipe cards to use stable card and image dimensions instead of resizing with source image proportions.
- Add recipe image aliases so recipes that previously used the placeholder image render relevant food imagery from existing assets.
- Keep the Health diagnostics page local-only by hiding it from production navigation and disabling the production route.
- Compact the Home carousel while preserving useful recipe context, slide actions, dot navigation, previous/next controls, and pause/resume behavior.

## Verification
- `npm.cmd run build`
- Verified the production bundle no longer includes `/health` route strings.

## Notes
- Browser automation was not available in this session; Vite preview did not stay running for a local visual pass, so verification is build and bundle based.